### PR TITLE
Add transform macro to service provider and relevant unit tests.

### DIFF
--- a/src/PresenterServiceProvider.php
+++ b/src/PresenterServiceProvider.php
@@ -14,6 +14,12 @@ class PresenterServiceProvider extends ServiceProvider
                 return present($object, $class);
             });
         });
+
+        Collection::macro('presentTransformed', function ($class) {
+            return $this->transform(function ($object) use ($class) {
+                return present($object, $class);
+            });
+        });
     }
 
     public function register()


### PR DESCRIPTION
Great package - really like this implementation of the Presenter pattern way more than most of the other Laravel-targeted packages out there, so thanks for your work on it.

This PR adds a new macro to collections that exposes a `presentTranformed` method for working with presenters and collections - whereas the existing present macro returns a new Collection, this one transforms the existing collection in place, which makes it a perfect fit for using with pagination, as per the issue #4.

The problem with the existing macro implementation is that the `present` method was returning a new collection that the paginator couldn't really take advantage of without manually stitching the data back together (the solution offered up in issue #4), but this new macro allows that pseudo code to be replaced with:

```php
Model::paginate(20)->presentTransformed(ModelPresenter::class);
```

This will update the internal paginator's collection to house the presenter wrapped models without interfering with the operation of the either the paginator itself nor the presenters/models.

The only thing I'm not really happy with is the method name, but given that it's modifying the collection in place, something the Collection class avoids beyond that one `transform` method of its own, I wanted to make the name very obvious in what it was doing and what the intent was, so whilst I don't really _like_ the name, it seemed like the most natural choice.