### PR TITLE
Adds getOriginalModel method

### DIFF
--- a/src/Presenter.php
+++ b/src/Presenter.php
@@ -61,7 +61,7 @@ abstract class Presenter implements Jsonable, Arrayable
 
     /**
      * Get the decorated model
-     * @var Illuminate/Database/Eloquent/Model|Hemp/Presneter/Presenter
+     * @return Illuminate/Database/Eloquent/Model|Hemp/Presneter/Presenter
      */
     public function getModel()
     {

--- a/src/Presenter.php
+++ b/src/Presenter.php
@@ -34,9 +34,15 @@ abstract class Presenter implements Jsonable, Arrayable
 
     /**
      * The decorated model
-     * @var Illuminate/Database/Eloquent/Model
+     * @var Illuminate/Database/Eloquent/Model|Hemp/Presenter/Presenter
      */
     protected $model;
+
+    /**
+     * The original, undecorated model.
+     * @var Illuminate/Database/Eloquent/Model
+     */
+    protected $originalModel;
 
     /**
      * Create a new instance of the Presenter
@@ -45,15 +51,30 @@ abstract class Presenter implements Jsonable, Arrayable
     public function __construct($model)
     {
         $this->model = $model;
+
+        if ($this->model instanceof Presenter) {
+            $model = $model->getOriginalModel();
+        }
+
+        $this->originalModel = $model;
     }
 
     /**
      * Get the decorated model
-     * @return Illuminate/Database/Eloquent/Model
+     * @var Illuminate/Database/Eloquent/Model|Hemp/Presneter/Presenter
      */
     public function getModel()
     {
         return $this->model;
+    }
+
+    /**
+     * Get the original, undecorated model
+     * @return Illuminate/Database/Eloquent/Model
+     */
+    public function getOriginalModel()
+    {
+        return $this->originalModel;
     }
 
     /**

--- a/tests/PresenterTest.php
+++ b/tests/PresenterTest.php
@@ -88,6 +88,26 @@ class PresenterTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function you_can_get_the_decorated_presenters()
+    {
+        $sampleModel = $this->createModel();
+        $presenter = new SamplePresenter($sampleModel);
+        $otherPresenter = new OtherSamplePresenter($presenter);
+
+        $this->assertSame($presenter, $otherPresenter->getModel());
+    }
+
+    /** @test */
+    public function you_can_get_the_original_model()
+    {
+        $sampleModel = $this->createModel();
+        $presenter = new SamplePresenter($sampleModel);
+        $presenter = new OtherSamplePresenter($presenter);
+
+        $this->assertSame($sampleModel, $presenter->getOriginalModel());
+    }
+
+    /** @test */
     public function it_can_have_its_own_methods()
     {
         $sampleModel = $this->createModel();


### PR DESCRIPTION
Fixes issue #14, or at the very least offers a work around to allow access to the original undecorated model where required.