### PR TITLE
Adds array access interface to presenter class and supporting unit tests

### DIFF
--- a/src/Presenter.php
+++ b/src/Presenter.php
@@ -5,8 +5,10 @@ namespace Hemp\Presenter;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
+use ArrayAccess;
+use BadMethodCallException;
 
-abstract class Presenter implements Jsonable, Arrayable
+abstract class Presenter implements Jsonable, Arrayable, ArrayAccess
 {
     /**
      * The attributes that should be visible in arrays.
@@ -260,5 +262,67 @@ abstract class Presenter implements Jsonable, Arrayable
         }
 
         return $values;
+    }
+
+     /**
+     * Return true if the property is set and not null.
+     *
+     * @param string $name
+     * @return bool
+     */
+    public function __isset($name)
+    {
+        return $this->offsetExists($name);
+    }
+
+    /**
+     * Return true if the offset exists and is not null.
+     *
+     * @param mixed $offset
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return $this->{$offset} !== null;
+    }
+
+    /**
+     * Return the value at the specified offset.
+     *
+     * @param mixed $offset
+     * @return mixed
+     */
+    public function offsetGet($offset)
+    {
+        return $this->{$offset};
+    }
+
+    /**
+     * Required implementation to satisfy the ArrayAccess interface,
+     * but throws as a BadMethodCallException as this is a read only
+     * implementation.
+     *
+     * @param mixed $offset
+     * @param mixed $value
+     * @return void
+     * @throws \BadMethodCallException
+     */
+    public function offsetSet($offset, $value)
+    {
+        throw new BadMethodCallException('Not implemented - read only implementation.');
+    }
+
+    /**
+     * Required implementation to satisfy the ArrayAccess interface,
+     * but throws as a BadMethodCallException as this is a read only
+     * implementation.
+     *
+     * @param mixed $offset
+     * @return void
+     * @throws \BadMethodCallException
+     */
+    public function offsetUnset($offset)
+    {
+        throw new BadMethodCallException('Not implemented - read only implementation.');
     }
 }

--- a/tests/PresenterTest.php
+++ b/tests/PresenterTest.php
@@ -214,6 +214,23 @@ class PresenterTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function you_can_access_a_collection_of_eloquent_models()
+    {
+        $sampleModel = $this->createModel();
+
+        $users = collect([$sampleModel])->present(SamplePresenter::class);
+
+        $this->assertEquals(
+            collect(['David']),
+            $users->pluck('first_name')
+        );
+
+        $this->assertEquals(
+            collect(['David Lee Hemphill']),
+            $users->pluck('full_name'));
+    }
+
+    /** @test */
     public function you_can_present_a_collection_of_models_using_a_closure()
     {
         $sampleModel = $this->createModel();
@@ -496,6 +513,40 @@ class PresenterTest extends PHPUnit_Framework_TestCase
         ]);
 
         $this->assertEquals($desired, (string) $presentedModel);
+    }
+
+    /** @test */
+    public function it_can_be_array_accessed()
+    {
+        $sampleModel = TestModel::create([
+            'first_name' => 'David',
+            'last_name' => 'Hemphill',
+            'created_at' => '2015-10-14 12:00:00',
+            'updated_at' => '2015-10-14 12:00:00',
+        ]);
+
+        $presenter = $sampleModel->present(SamplePresenter::class);
+
+        $this->assertEquals('David', $presenter['first_name']);
+
+        $this->assertEquals('David Lee Hemphill', $presenter['full_name']);
+    }
+
+    /** @test */
+    public function it_cannot_be_written_to_via_array_access()
+    {
+        $sampleModel = TestModel::create([
+            'first_name' => 'David',
+            'last_name' => 'Hemphill',
+            'created_at' => '2015-10-14 12:00:00',
+            'updated_at' => '2015-10-14 12:00:00',
+        ]);
+
+        $presenter = $sampleModel->present(SamplePresenter::class);
+
+        $this->setExpectedException(\BadMethodCallException::class);
+
+        $presenter['first_name'] = 'should not update';
     }
 }
 

--- a/tests/PresenterTest.php
+++ b/tests/PresenterTest.php
@@ -532,7 +532,10 @@ class PresenterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('David Lee Hemphill', $presenter['full_name']);
     }
 
-    /** @test */
+    /**
+     * @test 
+     * @expectedException BadMethodCallException
+     * */
     public function it_cannot_be_written_to_via_array_access()
     {
         $sampleModel = TestModel::create([
@@ -543,8 +546,6 @@ class PresenterTest extends PHPUnit_Framework_TestCase
         ]);
 
         $presenter = $sampleModel->present(SamplePresenter::class);
-
-        $this->setExpectedException(\BadMethodCallException::class);
 
         $presenter['first_name'] = 'should not update';
     }


### PR DESCRIPTION
There's currently an issue with accessing presented models still within Collections due to Laravel's Collection testing whether an item in the collection is an instance of `array` or `ArrayAccess`.  You can see the behaviour in the follow test example:

```php
$users = User::all();

//The following would output a collection of all the email addresses from each model.
var_dump($users->pluck('email')); 

$presentedUsers = $users->present(ExamplePresenter::class);

//The following would output a collection containing a null entry for each user,
//because it's unable to read the email address from the presented model.
var_dump($presentedUsers->pluck('email'));
```

This patch adds a read only implementation of the array access interface to the Presenter class which which would make the above test case return the expected result set, with the email address being correctly returned in both scenarios.  Unit test cases have been added to cover the changes, too.

Whilst I was adding this in, I've also tacked on an implementation of the magic `__isset` method which was missing and made calls to `isset` and `empty` always return false previously - it seemed like a good point to add it since its logic is essentially identical to offsetExists.