### PR TITLE
Add support for `defaultPresenter` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Or use the `Presentable` trait on your model and call `present` on it:
 $presentedUser = User::first()->present(ApiPresenter::class);
 ```
 
+Or, when using the `Presentable` trait, specify a default presenter using the `defaultPresenter` attribute on the Model and call `present` to use it:
+
+```php
+$presentedUser = User::first()->present();
+```
+
 Use the `present` macro on a Collection object:
 
 ```php

--- a/src/Presentable.php
+++ b/src/Presentable.php
@@ -8,11 +8,18 @@ trait Presentable
 {
     /**
      * Present this instance using the provided Presenter class
-     * @param  string $presenter
+     * @param  ?string $presenter
      * @return Hemp\Presenter
      */
-    public function present($presenter)
+    public function present($presenter = null)
     {
+        if (!$presenter) {
+            if (!$this->defaultPresenter) {
+                throw new \BadMethodCallException('No presenter or default presenter passed to present()');
+            }
+            $presenter = $this->defaultPresenter;
+        }
+
         $factory = new PresenterFactory;
         return $factory($this, $presenter);
     }

--- a/tests/PresenterTest.php
+++ b/tests/PresenterTest.php
@@ -69,6 +69,11 @@ class PresenterTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
+    public function createModelWithDefaultPresenter()
+    {
+        return new TestModelWithDefaultPresenter();
+    }
+
     /** @test */
     public function it_decorates_objects()
     {
@@ -158,6 +163,23 @@ class PresenterTest extends PHPUnit_Framework_TestCase
        $presentedModel = $this->createModel()->present(SamplePresenter::class);
 
        $this->assertInstanceOf(Presenter::class, $presentedModel);
+   }
+
+   /** @test */
+   public function you_can_call_present_on_an_eloquent_model_using_the_trait_and_use_default_presenter()
+   {
+       $presentedModel = $this->createModelWithDefaultPresenter()->present();
+
+       $this->assertInstanceOf(SamplePresenter::class, $presentedModel);
+   }
+
+   /**
+    * @test
+    * @expectedException     BadMethodCallException
+    */
+   public function you_can_not_call_present_on_an_eloquent_model_without_default_presenter_or_presenter()
+   {
+       $presentedModel = $this->createModel()->present();
    }
 
    /** @test */
@@ -533,7 +555,7 @@ class PresenterTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @test 
+     * @test
      * @expectedException BadMethodCallException
      * */
     public function it_cannot_be_written_to_via_array_access()
@@ -566,6 +588,12 @@ class TestModel extends Model
     {
         return 90210;
     }
+}
+
+class TestModelWithDefaultPresenter extends Model {
+    use Presentable;
+
+    protected $defaultPresenter = SamplePresenter::class;
 }
 
 class HideAttributesPresenter extends Presenter


### PR DESCRIPTION
I thought it would be useful to have a `defaultPresenter` for your Model so that you don't need to repeatedly pass your Model-specific presenter to `present`:

```php
<?php

namespace App\User;
use App\Presenters\UserPresenter;
use Hemp\Presenter\Presentable;
use Illuminate\Database\Eloquent\Model;

class User extends Model
{
    use Presentable;
    protected $defaultPresenter = UserPresenter::class;
}
?>
```

`Presentable` automatically throws a `BadMethodCallException` when neither a `defaultPresenter` nor a `presenter` argument is present.