### PR TITLE
Added magic __isset check for presenter to work for objects properties

### DIFF
--- a/src/Presenter.php
+++ b/src/Presenter.php
@@ -140,6 +140,24 @@ abstract class Presenter implements ArrayAccess, Arrayable, Jsonable
     }
 
     /**
+     * Dynamically check a property exists on the underlying object.
+     *
+     * @param  mixed  $attribute
+     * @return bool
+     */
+    public function __isset($attribute)
+    {
+        $method = $this->getStudlyAttributeMethod($attribute);
+
+        if (method_exists($this, $method)) {
+            $value = $this->{$method}($this->model);
+            return isset($value);
+        }
+
+        return isset($this->model->{$attribute});
+    }
+
+    /**
      * Convert the Presenter to a string.
      *
      * @return string

--- a/src/Presenter.php
+++ b/src/Presenter.php
@@ -151,6 +151,7 @@ abstract class Presenter implements ArrayAccess, Arrayable, Jsonable
 
         if (method_exists($this, $method)) {
             $value = $this->{$method}($this->model);
+
             return isset($value);
         }
 

--- a/src/Presenter.php
+++ b/src/Presenter.php
@@ -152,7 +152,7 @@ abstract class Presenter implements ArrayAccess, Arrayable, Jsonable
         if (method_exists($this, $method)) {
             $value = $this->{$method}($this->model);
 
-            return isset($value);
+            return ! is_null($value);
         }
 
         return isset($this->model->{$attribute});

--- a/tests/PresenterTest.php
+++ b/tests/PresenterTest.php
@@ -449,4 +449,44 @@ class PresenterTest extends IntegrationTest
 
         unset($presenter['email']);
     }
+
+    /** @test */
+    public function can_check_isset_on_presenter_for_model_attribute()
+    {
+        $presenter = factory(User::class)
+            ->create(['name' => 'David Hemphill'])
+            ->present(UserProfilePresenter::class);
+
+        $this->assertTrue(isset($presenter->name));
+    }
+
+    /** @test */
+    public function can_check_isset_on_presenter_for_accessor()
+    {
+        $user = factory(User::class)->create();
+        $presenter = new class($user) extends Presenter
+        {
+            public function getSayHelloAttribute()
+            {
+                return 'Hello from the Presenter!';
+            }
+        };
+
+        $this->assertTrue(isset($presenter->say_hello));
+    }
+
+    /** @test */
+    public function can_check_isset_is_false_on_presenter_for_accessor_if_returns_null()
+    {
+        $user = factory(User::class)->create();
+        $presenter = new class($user) extends Presenter
+        {
+            public function getSayHelloAttribute()
+            {
+                return null;
+            }
+        };
+
+        $this->assertFalse(isset($presenter->say_hello));
+    }
 }


### PR DESCRIPTION
Added magic isset check for underlying object properties.

e.g
```
$var = new Model();
$var->property = 'hello';
$presented = $var->present();

var_dump(isset($presented)->property)) // outputs false
```

We're using this package in Laravel and when used in conjunction with the `optional()` function. When used along with a presented model it always returns false when the underlying `isset` is checked using in conjunction with null coalesce for example.